### PR TITLE
added an input associations flag for the IEEE template

### DIFF
--- a/ieeetran/README.md
+++ b/ieeetran/README.md
@@ -14,6 +14,7 @@ Variables have two potential configuration points, which will be described here.
 5. `my columns` - defines the number of columns for the document to use, defaulting to `onecolumn` if undefined.
 6. `my doc class` - defines the document style to use, either `conference` (default) or `journal`.
 7. `my keywords` - keywords for this document
+8. `myassociation`,`$ASSOCIATION` - if included, association of the paper author
 
 ## LaTeX Variables
 

--- a/ieeetran/setup.tex
+++ b/ieeetran/setup.tex
@@ -8,6 +8,7 @@
 \fi
 
 \documentclass[10pt,\mydocclass,\mycolumns]{IEEEtran}
+\IEEEoverridecommandlockouts
 
 \usepackage{graphics}
 \usepackage{graphicx}
@@ -49,7 +50,12 @@
 \fi
 
 \title{\mytitle}
-\author{\myauthor}
+
+\ifx\myassociation\undefined
+\author{\IEEEauthorblockN{\myauthor}}
+\else
+\author{\IEEEauthorblockN{\myauthor} \IEEEauthorblockA{\myassociation}}
+\fi
 
 \begin{document}
 


### PR DESCRIPTION
Added an associations flag for the template to consider using associations, if provided. 

Also started using the author name block format provided by the IEEE class.
The associations will also use the author affiliation block provided by the IEEE class.

Added the override command lockouts flag to enable the use of the `thanks` command when setting up the authors.