### PR TITLE
Fix default template configuration

### DIFF
--- a/ieeeconf/frontmatter.mmd
+++ b/ieeeconf/frontmatter.mmd
@@ -1,4 +1,4 @@
-Base Header Level: 2
+Base Header Level: 3
 latex author: $AUTHOR
 latex title: $TITLE
 bibtex: $BIBTEX

--- a/ieeeconf/setup.tex
+++ b/ieeeconf/setup.tex
@@ -33,7 +33,6 @@
 \usepackage{url}
 \usepackage{hyperref}
 %for references
-\usepackage{apalike}
 \usepackage{tabulary}
 \usepackage{booktabs}
 


### PR DESCRIPTION
This removes the apalike package, which is a style for the unused bibtex package. Also defines the base header level as 3, as conference papers do not have chapters.